### PR TITLE
Check rangeCount before getRangeAt(0)

### DIFF
--- a/hterm/js/hterm_screen.js
+++ b/hterm/js/hterm_screen.js
@@ -927,6 +927,10 @@ hterm.Screen.prototype.expandSelectionWithWordBreakMatches_ =
     return;
   }
 
+  if (selection.rangeCount == 0) {
+    return;
+  }
+
   const range = selection.getRangeAt(0);
   if (!range || range.toString().match(/\s/)) {
     return;


### PR DESCRIPTION
Apparently on WebKit (including ish's webview), getSelection() can return an object with no ranges (rangeCount == 0).

In those cases, calling getRangeAt(0) causes an error to be thrown: "IndexSizeError: The index is not in the allowed range"

This error was appearing in the JS console when tapping/clicking randomly. Checking rangeCount here fixes the error.

See also:
https://stackoverflow.com/questions/22935320/uncaught-indexsizeerror-failed-to-execute-getrangeat-on-selection-0-is-not